### PR TITLE
Fix: failure to handle extra if env is not empty but does noot have extra

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -58,6 +58,16 @@ dev = [
     "pytest>=7.4.3",
 ]
 
+[tool.pdm.scripts]
+test = "pytest"
+
+[tool.pytest.ini_options]
+addopts = "-ra"
+testpaths = [
+  "src/",
+  "tests/",
+]
+
 [tool.pyright]
 venvPath = "."
 venv = ".venv"

--- a/src/dep_logic/markers/single.py
+++ b/src/dep_logic/markers/single.py
@@ -46,7 +46,7 @@ class SingleMarker(BaseMarker):
 
     def evaluate(self, environment: dict[str, str] | None = None) -> bool:
         pkg_marker = _Marker(str(self))
-        if self.name != "extra" or not environment:
+        if self.name != "extra" or not environment or "extra" not in environment:
             return pkg_marker.evaluate(environment)
         extras = [extra] if isinstance(extra := environment["extra"], str) else extra
         assert isinstance(self, MarkerExpression)

--- a/tests/marker/test_evaluation.py
+++ b/tests/marker/test_evaluation.py
@@ -107,6 +107,8 @@ def test_evaluates(
         # single extra
         ("extra != 'security'", {"extra": "quux"}, True),
         ("extra != 'security'", {"extra": "security"}, False),
+        ("extra != 'security'", {}, True),
+        ("extra != 'security'", {"platform_machine": "x86_64"}, True),
         # normalization
         ("extra == 'Security.1'", {"extra": "security-1"}, True),
         ("extra == 'a'", {}, False),


### PR DESCRIPTION
Since `pdm==2.11` is out, we are not able to perform install anymore because markers evaluation fail on `extra` for environment not having `extra` but not being empty neither.

This PR reproduce this in a test and fix it.

Note: I added the `test` script but I can remove the commit