### PR TITLE
Improve logic for detecting msys2-based Python (works for 3.11 and 3.…

### DIFF
--- a/src/dep_logic/tags/platform.py
+++ b/src/dep_logic/tags/platform.py
@@ -106,7 +106,6 @@ class Platform:
 
         platform_ = sysconfig.get_platform()
         platform_info = platform_.split("-", 1)
-        architecture: str | None = None
         if len(platform_info) == 1:
             if platform_info[0] == "win32":
                 return cls(os.Windows(), Arch.X86)

--- a/src/dep_logic/tags/platform.py
+++ b/src/dep_logic/tags/platform.py
@@ -7,7 +7,7 @@ import sys
 from dataclasses import dataclass
 from enum import Enum
 from functools import cached_property
-from typing import TYPE_CHECKING, Optional
+from typing import TYPE_CHECKING
 
 from . import os
 
@@ -106,24 +106,24 @@ class Platform:
 
         platform_ = sysconfig.get_platform()
         platform_info = platform_.split("-", 1)
-        architecture: Optional[str] = None
+        architecture: str | None = None
         if len(platform_info) == 1:
             if platform_info[0] == "win32":
                 return cls(os.Windows(), Arch.X86)
             operating_system, _, version_arch = (
                 platform_.replace(".", "_").replace(" ", "_").partition("_")
             )
-            if version_arch.startswith("x86_64"):
-                architecture = "x86_64"
         else:
             operating_system, version_arch = platform_info
         if "-" in version_arch:
             # Ex: macosx-11.2-arm64
             version, architecture = version_arch.rsplit("-", 1)
-        elif not architecture:
-            # Ex: linux-x86_64
+        else:
+            # Ex: linux-x86_64 or x86_64_msvcrt_gnu
             version = None
             architecture = version_arch
+            if version_arch.startswith("x86_64"):
+                architecture = "x86_64"
 
         if operating_system == "linux":
             from packaging._manylinux import _get_glibc_version

--- a/src/dep_logic/tags/platform.py
+++ b/src/dep_logic/tags/platform.py
@@ -7,7 +7,7 @@ import sys
 from dataclasses import dataclass
 from enum import Enum
 from functools import cached_property
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Optional
 
 from . import os
 
@@ -106,18 +106,21 @@ class Platform:
 
         platform_ = sysconfig.get_platform()
         platform_info = platform_.split("-", 1)
+        architecture: Optional[str] = None
         if len(platform_info) == 1:
             if platform_info[0] == "win32":
                 return cls(os.Windows(), Arch.X86)
             operating_system, _, version_arch = (
                 platform_.replace(".", "_").replace(" ", "_").partition("_")
             )
+            if version_arch.startswith("x86_64"):
+                architecture = "x86_64"
         else:
             operating_system, version_arch = platform_info
         if "-" in version_arch:
             # Ex: macosx-11.2-arm64
             version, architecture = version_arch.rsplit("-", 1)
-        else:
+        elif not architecture:
             # Ex: linux-x86_64
             version = None
             architecture = version_arch


### PR DESCRIPTION
…12).

The MSYS2 project [standardized](https://github.com/msys2/MINGW-packages/blob/master/mingw-w64-python/0117-sysconfig.get_platform-use-consistent-naming.patch) sysconfig names for 3.12, resulting in errors such as the following after an upgrade:

```
$ pdm run -v test.py pipx
INFO: Reusing existing script environment: C:/Users/William/AppData/Local/pdm/pdm/venvs/2fa106ce3fc8b29bf047ce91804516ef
Traceback (most recent call last):
  File "C:/msys64/home/William/Projects/python/pdm/src/pdm/models/in_process/env_spec.py", line 25, in <module>
    print(json.dumps(get_current_env_spec(), indent=2))
                     ^^^^^^^^^^^^^^^^^^^^^^
  File "C:/msys64/home/William/Projects/python/pdm/src/pdm/models/in_process/env_spec.py", line 16, in get_current_env_spec
    "platform": str(Platform.current()),
                    ^^^^^^^^^^^^^^^^^^
  File "C:/msys64/home/William/Projects/python/dep-logic/src/dep_logic/tags/platform.py", line 164, in current
    return cls(os_, Arch.parse(architecture))
                    ^^^^^^^^^^^^^^^^^^^^^^^^
  File "C:/msys64/home/William/Projects/python/dep-logic/src/dep_logic/tags/platform.py", line 390, in parse
    return cls(arch)
           ^^^^^^^^^
  File "C:/msys64/mingw64/lib/python3.12/enum.py", line 757, in __call__
    return cls.__new__(cls, value)
           ^^^^^^^^^^^^^^^^^^^^^^^
  File "C:/msys64/mingw64/lib/python3.12/enum.py", line 1171, in __new__
    raise ve_exc
ValueError: 'x86_64_msvcrt_gnu' is not a valid Arch
```

This PR slightly changes the logic introduced by https://github.com/pdm-project/pdm/issues/3158 for detecting the arch in the MSYS2 case (works for 3.12 and while I don't have 3.11 to test right now, I checked that the `mingw_x86_64` string also triggers my updated logic.