### PR TITLE
feat(tags): basic loongarch64 support

### DIFF
--- a/src/dep_logic/tags/platform.py
+++ b/src/dep_logic/tags/platform.py
@@ -337,6 +337,7 @@ class Arch(Enum):
     X86_64 = "x86_64"
     S390X = "s390x"
     RISCV64 = "riscv64"
+    LoongArch64 = "loongarch64"
 
     def __str__(self) -> str:
         return self.value


### PR DESCRIPTION
This is a minimal change that makes pdm work on loongarch64.