### PR TITLE
fix: mark broken python tag as incompatible

### DIFF
--- a/src/dep_logic/tags/tags.py
+++ b/src/dep_logic/tags/tags.py
@@ -155,7 +155,10 @@ class EnvSpec:
         self, python_tag: str, abi_tag: str
     ) -> tuple[int, int, int] | None:
         """Return a tuple of (major, minor, abi) if the wheel is compatible with the environment, or None otherwise."""
-        impl, major, minor = python_tag[:2], python_tag[2:3], python_tag[3:]
+        try:
+            impl, major, minor = python_tag[:2], python_tag[2:3], python_tag[3:]
+        except IndexError:
+            return None
         if self.implementation is not None and impl not in [
             self.implementation.short,
             "py",


### PR DESCRIPTION
While trying to resolve dependencies after adding `mkdocs-material` to a project, `dep-logic` kept crashing with an `IndexError` around a tag for package `backrefs`. When looking into it, that project seems to have published [some questionable files](https://pypi.org/project/backrefs/5.0/#files) for version 5.0 (using tag `36` instead of `py36`). While unfortunate, this completely breaks trying to update dependencies, rather than ignoring those files or marking them incompatible.

Not sure this fix is in the right spot as it is (could be better suited to `parse_wheel_tags`), open to changing this up and adding a test for this. Please suggest improvements or edit this PR as needed. Would also normally add a line comment about this, but noticed the project uses those very sparingly, so opted against that for now; please advise :)

<details>

<summary>
Full traceback (local paths redacted) of the original error while running `pdm update --update-all`:
</summary>

```
Traceback (most recent call last):
  File ".../bin/pdm", line 8, in <module>
    sys.exit(main())
  File ".../pipx/venvs/pdm/lib/python3.10/site-packages/pdm/core.py", line 392, in main
    return core.main(args or sys.argv[1:])
  File ".../pipx/venvs/pdm/lib/python3.10/site-packages/pdm/core.py", line 270, in main
    raise cast(Exception, err).with_traceback(traceback) from None
  File ".../pipx/venvs/pdm/lib/python3.10/site-packages/pdm/core.py", line 265, in main
    self.handle(project, options)
  File ".../pipx/venvs/pdm/lib/python3.10/site-packages/pdm/core.py", line 195, in handle
    command.handle(project, options)
  File ".../pipx/venvs/pdm/lib/python3.10/site-packages/pdm/cli/commands/update.py", line 75, in handle
    self.do_update(
  File ".../pipx/venvs/pdm/lib/python3.10/site-packages/pdm/cli/commands/update.py", line 181, in do_update
    resolved = do_lock(
  File ".../pipx/venvs/pdm/lib/python3.10/site-packages/pdm/cli/actions.py", line 133, in do_lock
    resolved, collected_groups = resolver.resolve()
  File ".../pipx/venvs/pdm/lib/python3.10/site-packages/pdm/resolver/resolvelib.py", line 51, in resolve
    mapping = self._do_resolve()
  File ".../pipx/venvs/pdm/lib/python3.10/site-packages/pdm/resolver/resolvelib.py", line 89, in _do_resolve
    result = resolver.resolve(requirements, max_rounds)
  File ".../pipx/venvs/pdm/lib/python3.10/site-packages/resolvelib/resolvers/resolution.py", line 515, in resolve
    state = resolution.resolve(requirements, max_rounds=max_rounds)
  File ".../pipx/venvs/pdm/lib/python3.10/site-packages/resolvelib/resolvers/resolution.py", line 444, in resolve
    failure_criterion = self._attempt_to_pin_criterion(name)
  File ".../pipx/venvs/pdm/lib/python3.10/site-packages/resolvelib/resolvers/resolution.py", line 211, in _attempt_to_pin_criterion
    criteria = self._get_updated_criteria(candidate)
  File ".../pipx/venvs/pdm/lib/python3.10/site-packages/resolvelib/resolvers/resolution.py", line 202, in _get_updated_criteria
    self._add_to_criteria(criteria, requirement, parent=candidate)
  File ".../pipx/venvs/pdm/lib/python3.10/site-packages/resolvelib/resolvers/resolution.py", line 141, in _add_to_criteria
    if not criterion.candidates:
  File ".../pipx/venvs/pdm/lib/python3.10/site-packages/resolvelib/structs.py", line 169, in __bool__
    next(iter(self))
  File ".../pipx/venvs/pdm/lib/python3.10/site-packages/pdm/resolver/providers.py", line 246, in <genexpr>
    return (
  File ".../pipx/venvs/pdm/lib/python3.10/site-packages/pdm/resolver/providers.py", line 189, in _find_candidates
    found = self.repository.find_candidates(
  File ".../pipx/venvs/pdm/lib/python3.10/site-packages/pdm/models/repositories/base.py", line 178, in find_candidates
    cans = LazySequence(self._find_candidates(requirement, minimal_version=minimal_version))
  File ".../pipx/venvs/pdm/lib/python3.10/site-packages/pdm/models/repositories/pypi.py", line 66, in _find_candidates
    for c in finder.find_all_packages(req_name, allow_yanked=requirement.is_pinned)
  File ".../pipx/venvs/pdm/lib/python3.10/site-packages/unearth/finder.py", line 315, in find_all_packages
    self._find_packages(package_name, allow_yanked), hashes=hashes or {}
  File ".../pipx/venvs/pdm/lib/python3.10/site-packages/unearth/finder.py", line 295, in _find_packages
    return sorted(all_packages, key=self._sort_key, reverse=True)
  File ".../pipx/venvs/pdm/lib/python3.10/site-packages/unearth/evaluator.py", line 234, in evaluate_link
    self.check_wheel_tags(link.filename)
  File ".../pipx/venvs/pdm/lib/python3.10/site-packages/pdm/models/finder.py", line 56, in check_wheel_tags
    if self.env_spec.wheel_compatibility(filename) is None:
  File ".../pipx/venvs/pdm/lib/python3.10/site-packages/dep_logic/tags/tags.py", line 249, in wheel_compatibility
    return self.compatibility(
  File ".../pipx/venvs/pdm/lib/python3.10/site-packages/dep_logic/tags/tags.py", line 226, in compatibility
    python_compat = max(
  File ".../pipx/venvs/pdm/lib/python3.10/site-packages/dep_logic/tags/tags.py", line 228, in <genexpr>
    None, (self._evaluate_python(*comb) for comb in python_abi_combinations)
  File ".../pipx/venvs/pdm/lib/python3.10/site-packages/dep_logic/tags/tags.py", line 158, in _evaluate_python
    impl, major, minor = python_tag[:2], python_tag[2], python_tag[3:]
IndexError: string index out of range
```
</details>