### PR TITLE
fix: invert __contains__ logic for Any-/EmptySpecifier

### DIFF
--- a/src/dep_logic/specifiers/special.py
+++ b/src/dep_logic/specifiers/special.py
@@ -36,7 +36,7 @@ class EmptySpecifier(BaseSpecifier):
         return True
 
     def __contains__(self, value: str) -> bool:
-        return True
+        return False
 
 
 class AnySpecifier(BaseSpecifier):
@@ -72,4 +72,4 @@ class AnySpecifier(BaseSpecifier):
         return True
 
     def __contains__(self, value: str) -> bool:
-        return False
+        return True


### PR DESCRIPTION
fixes #12 