### PR TITLE
fix: explicitly check for invalid versions in more places

### DIFF
--- a/src/dep_logic/markers/single.py
+++ b/src/dep_logic/markers/single.py
@@ -8,7 +8,7 @@ from dataclasses import dataclass, field, replace
 
 from packaging.markers import default_environment
 from packaging.specifiers import InvalidSpecifier, Specifier
-from packaging.version import InvalidVersion
+from packaging.version import InvalidVersion, Version
 
 from dep_logic.markers.any import AnyMarker
 from dep_logic.markers.base import BaseMarker, EvaluationContext
@@ -202,7 +202,7 @@ class MarkerExpression(SingleMarker):
                 pass
             else:
                 try:
-                    return spec.contains(lhs)
+                    return spec.contains(Version(lhs))
                 except InvalidVersion:
                     pass
 

--- a/src/dep_logic/specifiers/range.py
+++ b/src/dep_logic/specifiers/range.py
@@ -86,6 +86,8 @@ class RangeSpecifier(VersionSpecifier):
     def contains(
         self, version: UnparsedVersion, prereleases: bool | None = None
     ) -> bool:
+        if not isinstance(version, Version):
+            version = Version(version)
         return self.to_specifierset().contains(version, prereleases)
 
     def __invert__(self) -> BaseSpecifier:


### PR DESCRIPTION
`packaging` used to do this, but no longer does as of 26.0, causing a couple of test failures.

Fixes: #16