### PR TITLE
chore: require Python 3.9

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12", "3.13", "pypy3.9", "pypy3.10"]
+        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13", "pypy3.9", "pypy3.10"]
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13", "pypy3.9", "pypy3.10"]
+        python-version: ["3.9", "3.10", "3.11", "3.12", "3.13", "3.14", "pypy3.9", "pypy3.10"]
 
     steps:
       - uses: actions/checkout@v4

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Python dependency specifications supporting logical operations
 pip install dep-logic
 ```
 
-This library requires Python 3.8 or later.
+This library requires Python 3.9 or later.
 
 Currently, it contains two sub-modules:
 

--- a/pdm.lock
+++ b/pdm.lock
@@ -4,8 +4,11 @@
 [metadata]
 groups = ["default", "dev"]
 strategy = ["cross_platform", "inherit_metadata"]
-lock_version = "4.4.2"
-content_hash = "sha256:7fcb03ae06fee244b9af7cf9efb8e986ad48b8608e7a918f6ca9783f48470b23"
+lock_version = "4.5.0"
+content_hash = "sha256:e8e84e62db6c07f57769e416d7aa19fd4f3e00a46de828be940adbfb3778a3a3"
+
+[[metadata.targets]]
+requires_python = ">=3.9"
 
 [[package]]
 name = "colorama"

--- a/pdm.lock
+++ b/pdm.lock
@@ -3,7 +3,7 @@
 
 [metadata]
 groups = ["default", "dev"]
-strategy = ["cross_platform", "inherit_metadata"]
+strategy = ["inherit_metadata"]
 lock_version = "4.5.0"
 content_hash = "sha256:e8e84e62db6c07f57769e416d7aa19fd4f3e00a46de828be940adbfb3778a3a3"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ authors = [
 dependencies = [
     "packaging>=22",
 ]
-requires-python = ">=3.8"
+requires-python = ">=3.9"
 readme = "README.md"
 license = {text = "Apache-2.0"}
 dynamic = ["version"]
@@ -16,7 +16,6 @@ keywords = ["dependency", "specification", "logic", "packaging"]
 classifiers = [
     "Intended Audience :: Developers",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",


### PR DESCRIPTION
## Summary
- raise the package minimum Python version from 3.8 to 3.9
- remove CPython 3.8 from the CI matrix
- refresh the PDM lock metadata for the new Python target

## Validation
- pdm lock --check
- pdm run pytest